### PR TITLE
Adding "switch" support HatchBabyRest accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To add a Rest night light to your homebridge setup, first open the Hatch Baby Re
   "accessories": [
     {
       "accessory": "HatchBabyRest",
+      "service": "light",
       "name": "Kid's Night Light",
       "macAddress": "12:34:56:78:90:AB",
       "volume": 29,
@@ -55,6 +56,7 @@ The original Rest night light does not retain color/volume/audio track settings 
 Option | Required | Details
 --- | --- | ---
 accessory | `true` | _Must_ be `HatchBabyRest` to link it to this plugin
+service | `false` | Defines what type of service the Rest accessory uses.  Possible values are: `"switch"` for `Switch` and `"light"` for `LightBulb` (default)
 name | `true` | The name you want assigned to this light in HomeKit
 macAddress | `true` | The MAC address for the light, found in your Hatch Baby Rest app.  This is used to discover the light via bluetooth
 volume | `false` | The volume level to set the speaker of the light to when it is turned on.  Must be between 0 and 100.  If set to 0 or left blank, the speaker will not play music when turned on via HomeKit

--- a/config.schema.json
+++ b/config.schema.json
@@ -4,6 +4,12 @@
   "schema": {
     "type": "object",
     "properties": {
+      "service": {
+        "title": "Service Type",
+        "type": "string",
+        "placeholder": "Service Type",
+        "required": false
+      },
       "name": {
         "title": "Light Name",
         "type": "string",

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -7,7 +7,7 @@ import { colorsMatch } from '../src/feedback'
 
 async function example() {
   const macAddress = process.env.HBR_MAC_ADDRESS!,
-    hbr = new HatchBabyRest('Test Night Light', macAddress, console),
+    hbr = new HatchBabyRest('light', 'Test Night Light', macAddress, console),
     waitForPower = (power: boolean) =>
       hbr.onPower
         .pipe(

--- a/src/accessories/hatch-baby-rest.ts
+++ b/src/accessories/hatch-baby-rest.ts
@@ -6,15 +6,17 @@ import { AudioTrack } from '../hatch-baby-types'
 
 export class HatchBabyRestAccessory {
   private hbr = new HatchBabyRest(
+    this.config.service,
     this.config.name,
     this.config.macAddress,
     this.log
   )
-  private service = new hap.Service.Lightbulb(this.config.name)
+  private service: HAP.Service
 
   constructor(
     public log: HAP.Log,
     public config: {
+      service: string
       name: string
       macAddress: string
       volume?: number
@@ -22,6 +24,8 @@ export class HatchBabyRestAccessory {
       color?: Color
     }
   ) {
+    this.service = this.config.service == 'switch' ? new hap.Service.Switch(this.config.name) : new hap.Service.Lightbulb(this.config.name)
+
     const powerCharacteristic = this.service.getCharacteristic(
         hap.Characteristic.On
       ),

--- a/src/hatch-baby-rest.ts
+++ b/src/hatch-baby-rest.ts
@@ -77,6 +77,7 @@ export class HatchBabyRest {
   reconnectSubscription?: Subscription
 
   constructor(
+    private service: string,
     private name: string,
     private macAddress: string,
     private logger: HAP.Log


### PR DESCRIPTION
My baby's hatch was being deactivated by my catch-all turn off the lights at 2am rule...

I've added an optional `service` configuration parameter for the HatchBabyRest accessory, allowing the underlying HAP Service to be either a `LightBulb` ("light") or a `Switch` ("switch"). 

The `Switch` type allows the user to select from "Fan", "Switch" and "Light" in the Home app, giving greater flexibility.