### PR TITLE
fix(rest-iot): add early return to setting current routine

### DIFF
--- a/packages/homebridge-hatch-baby-rest/rest-iot.ts
+++ b/packages/homebridge-hatch-baby-rest/rest-iot.ts
@@ -46,6 +46,7 @@ export class RestIot extends IotDevice<RestIotState> implements BaseDevice {
 
   async turnOnRoutine() {
     const favorites = await this.fetchFavorites()
+    if (favorites.length === 0) return;
     this.setCurrent('routine', 1, favorites[0].id)
   }
 


### PR DESCRIPTION
Fixes #115 

There might be more to do in order to actually turn on a routine, this just resolves the error seen in the linked issue. Happy to make further updates or investigations with some help. 