### PR TITLE
Add exponential backoff to requestWithRetry

### DIFF
--- a/packages/homebridge-hatch-baby-rest/rest-client.ts
+++ b/packages/homebridge-hatch-baby-rest/rest-client.ts
@@ -17,6 +17,7 @@ export function apiPath(path: string) {
 
 export async function requestWithRetry<T>(
   options: RequestInit & { url: string; json?: object },
+  retryCount: number = 1,
 ): Promise<T> {
   try {
     const optionsWithDefaults: RequestInit = {
@@ -48,11 +49,23 @@ export async function requestWithRetry<T>(
     return responseJson as T
   } catch (e: any) {
     if (!e.response) {
+      // Maximum number of retries
+      const MAX_RETRIES = 10
+      if (retryCount >= MAX_RETRIES) {
+        throw new Error(
+          `Failed to reach Hatch Baby server at ${options.url} after ${MAX_RETRIES} retries. Giving up.`,
+        )
+      }
+
+      // Exponential backoff doubled each retry
+      // Cap at 30 seconds to avoid extremely long waits
+      const backoffTime = Math.min(1000 * Math.pow(2, retryCount), 30000)
+
       logError(
-        `Failed to reach Hatch Baby server at ${options.url}.  ${e.message}.  Trying again in 5 seconds...`,
+        `Failed to reach Hatch Baby server at ${options.url}. ${e.message}. Trying again in ${backoffTime / 1000} seconds... (Attempt ${retryCount + 1}/${MAX_RETRIES})`,
       )
-      await delay(5000)
-      return requestWithRetry(options)
+      await delay(backoffTime)
+      return requestWithRetry(options, retryCount + 1)
     }
 
     throw e


### PR DESCRIPTION

Reduce the extra calls if retry not successful.


This change updates `rest-client.ts` function `requestWithRetry` with:

- Adds a retryCount and increases the wait time between calls
- Adds max wait of 30 seconds
- Ends after 10 retry attempts