### PR TITLE
Add supply chain security defaults

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+    # Wait 3 days after a new release before opening routine version-update PRs.
+    # This does not affect Dependabot Security Updates.
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-actions:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,9 @@ name: Node CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm ci
 
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: npm run version
           publish: npm run release

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
Implement supply chain security measures by configuring Dependabot for weekly updates, setting a cooldown for routine version updates, and restricting permissions in the GitHub Actions workflow. Additionally, pin the changesets/action to a specific commit SHA and introduce a minimum release age for npm packages.