### PR TITLE
Update turbo cache strategy in CI workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
       # Enable turbo remote caching
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_REMOTE_ONLY: true
+      TURBO_CACHE: remote:rw
 
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # Enable turbo remote caching
+      # Enable turbo remote caching. The release workflow holds id-token:write
+      # (OIDC npm publishing), so it is write-only: it never restores a cache
+      # that a lower-trust run could have poisoned, but still populates it.
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_CACHE: remote:w
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # Enable turbo remote caching
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_REMOTE_ONLY: true
+      TURBO_CACHE: remote:rw
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Replace deprecated `TURBO_REMOTE_ONLY` with `TURBO_CACHE=remote:rw` for regular CI and set the release workflow to use `TURBO_CACHE=remote:w` to prevent cache poisoning while still populating the cache. This change enhances security and efficiency in the CI process.