### PR TITLE
Added `disableLogging` option to  silence routine log messages

### DIFF
--- a/packages/homebridge-hatch-baby-rest/api.ts
+++ b/packages/homebridge-hatch-baby-rest/api.ts
@@ -23,6 +23,7 @@ import { debounceTime } from 'rxjs/operators'
 
 export interface ApiConfig extends EmailAuth {
   debug?: boolean
+  disableLogging?: boolean
 }
 
 const knownProducts: Product[] = [

--- a/packages/homebridge-hatch-baby-rest/config.schema.json
+++ b/packages/homebridge-hatch-baby-rest/config.schema.json
@@ -16,6 +16,12 @@
         "type": "string",
         "placeholder": "Password",
         "required": false
+      },
+      "disableLogging": {
+        "title": "Disable Logging",
+        "description": "Silences routine logging such as device configuration and state changes",
+        "type": "boolean",
+        "required": false
       }
     }
   }

--- a/packages/homebridge-hatch-baby-rest/platform.ts
+++ b/packages/homebridge-hatch-baby-rest/platform.ts
@@ -1,6 +1,6 @@
 import { ApiConfig, HatchBabyApi } from './api.ts'
 import { hap, isTestHomebridge } from '../shared/hap.ts'
-import { useLogger } from '../shared/util.ts'
+import { disableInfo, logInfo, useLogger } from '../shared/util.ts'
 import { LightAndSoundMachineAccessory } from '../shared/light-and-sound-machine.ts'
 import { SoundMachineAccessory } from '../shared/sound-machine.ts'
 import type {
@@ -39,8 +39,12 @@ export class HatchBabyRestPlatform implements DynamicPlatformPlugin {
     })
 
     if (!config) {
-      this.log.info('No configuration found for platform HatchBabyRest')
+      this.log.warn('No configuration found for platform HatchBabyRest')
       return
+    }
+
+    if (this.config.disableLogging === true) {
+      disableInfo()
     }
 
     this.api.on('didFinishLaunching', () => {
@@ -55,7 +59,7 @@ export class HatchBabyRestPlatform implements DynamicPlatformPlugin {
   }
 
   configureAccessory(accessory: PlatformAccessory) {
-    this.log.info(
+    logInfo(
       `Configuring cached accessory ${accessory.UUID} ${accessory.displayName}`,
     )
     this.log.debug('%j', accessory)
@@ -107,7 +111,7 @@ export class HatchBabyRestPlatform implements DynamicPlatformPlugin {
         ...restBabies,
       ]
 
-    this.log.info('Configuring Hatch Devices:')
+    logInfo('Configuring Hatch Devices:')
 
     if (devices.length) {
       const countByModel = devices.reduce(
@@ -120,10 +124,10 @@ export class HatchBabyRestPlatform implements DynamicPlatformPlugin {
       )
 
       Object.entries(countByModel).forEach(([model, count]) => {
-        this.log.info(`  ${model}: ${count}`)
+        logInfo(`  ${model}: ${count}`)
       })
     } else {
-      this.log.info('  No supported devices found')
+      this.log.warn('  No supported devices found')
     }
 
     devices.forEach((device) => {

--- a/packages/homebridge-hatch-rest-bluetooth/config.schema.json
+++ b/packages/homebridge-hatch-rest-bluetooth/config.schema.json
@@ -25,6 +25,12 @@
             }
           }
         }
+      },
+      "disableLogging": {
+        "title": "Disable Logging",
+        "description": "Silences routine logging such as device configuration and state changes",
+        "type": "boolean",
+        "required": false
       }
     }
   }

--- a/packages/homebridge-hatch-rest-bluetooth/platform.ts
+++ b/packages/homebridge-hatch-rest-bluetooth/platform.ts
@@ -1,5 +1,5 @@
 import { hap, isTestHomebridge } from '../shared/hap.ts'
-import { useLogger } from '../shared/util.ts'
+import { disableInfo, logInfo, useLogger } from '../shared/util.ts'
 import { stripMacAddress } from './util.ts'
 import { LightAndSoundMachineAccessory } from '../shared/light-and-sound-machine.ts'
 import type {
@@ -51,8 +51,12 @@ export class HatchRestBluetoothPlatform implements DynamicPlatformPlugin {
     })
 
     if (!config) {
-      this.log.info('No configuration found for platform HatchBabyRest')
+      this.log.warn('No configuration found for platform HatchBabyRest')
       return
+    }
+
+    if (this.config.disableLogging === true) {
+      disableInfo()
     }
 
     this.api.on('didFinishLaunching', () => {
@@ -64,7 +68,7 @@ export class HatchRestBluetoothPlatform implements DynamicPlatformPlugin {
   }
 
   configureAccessory(accessory: PlatformAccessory) {
-    this.log.info(
+    logInfo(
       `Configuring cached accessory ${accessory.UUID} ${accessory.displayName}`,
     )
     this.log.debug('%j', accessory)
@@ -83,7 +87,7 @@ export class HatchRestBluetoothPlatform implements DynamicPlatformPlugin {
       debugPrefix = isTestHomebridge ? 'TEST ' : '',
       devices = restLights
 
-    this.log.info(`Configuring ${restLights.length} Rest Sound Machines`)
+    logInfo(`Configuring ${restLights.length} Rest Sound Machines`)
 
     devices.forEach((device) => {
       const id = stripMacAddress(device.macAddress),

--- a/packages/shared/util.ts
+++ b/packages/shared/util.ts
@@ -13,6 +13,7 @@ let logger: Logger = {
       console.error(message)
     },
   },
+  infoDisabled = false,
   debugEnabled = false
 
 export function logDebug(message: any) {
@@ -22,7 +23,9 @@ export function logDebug(message: any) {
 }
 
 export function logInfo(message: any) {
-  logger.logInfo(message)
+  if (!infoDisabled) {
+    logger.logInfo(message)
+  }
 }
 
 export function logError(message: any) {
@@ -35,6 +38,10 @@ export function useLogger(newLogger: Logger) {
 
 export function enableDebug() {
   debugEnabled = true
+}
+
+export function disableInfo() {
+  infoDisabled = true
 }
 
 export function delay(milliseconds: number) {


### PR DESCRIPTION
First off, thanks for the great plugin!

I'm personally a fan of the "silence is golden" philosophy, and keeping my Homebridge log minimal helps me pluck out important messages.

This PR adds a `disableLogin` config option to suppress `logInfo` messages. I made the minimal set of changes necessary to accomplish this, but please let me know if you'd prefer a different approach or if there are other changes you'd like me to make.

Thanks for considering!