### PR TITLE
fix: survive extended outages in AWS IoT client lifecycle

### DIFF
--- a/.changeset/iot-lifecycle-resilience.md
+++ b/.changeset/iot-lifecycle-resilience.md
@@ -1,0 +1,5 @@
+---
+"homebridge-hatch-baby-rest": patch
+---
+
+Survive extended network outages in the AWS IoT client lifecycle: create replacement MQTT clients before ending the previous one, retry failed client creation with backoff forever, recreate the client with fresh credentials when the SDK's built-in reconnect cannot recover, refresh credentials on an interval that survives failed refreshes, re-fetch the device shadow after SDK-internal reconnects, and attach the MQTT connect listener synchronously so the connect event is never missed.

--- a/packages/homebridge-hatch-baby-rest/api.ts
+++ b/packages/homebridge-hatch-baby-rest/api.ts
@@ -19,7 +19,6 @@ import { RestMini } from './rest-mini.ts'
 import { Restore } from './restore.ts'
 import { BehaviorSubject } from 'rxjs'
 import { IotDevice } from './iot-device.ts'
-import { debounceTime } from 'rxjs/operators'
 
 export interface ApiConfig extends EmailAuth {
   debug?: boolean
@@ -43,7 +42,15 @@ const knownProducts: Product[] = [
     Product.grow,
     Product.answeredReader,
   ],
-  iotClientRefreshPeriod = 50 * 60 * 1000 // refresh client every 50 minutes (AWS Cognito credentials expire after ~1 hour)
+  iotClientRefreshPeriod = 50 * 60 * 1000, // refresh client every 50 minutes (AWS Cognito credentials expire after ~1 hour)
+  iotClientInitialRetryDelay = 30 * 1000,
+  iotClientMaxRetryDelay = 5 * 60 * 1000,
+  // How long a client may sit disconnected (close/offline without a
+  // subsequent connect) before we stop trusting the SDK's built-in
+  // reconnect - its retries reuse the original signed websocket URL,
+  // whose Cognito credentials expire, so extended outages need a fresh
+  // client with fresh credentials
+  iotClientDeadConnectionTimeout = 10 * 60 * 1000
 
 export class HatchBabyApi {
   public readonly config
@@ -112,25 +119,51 @@ export class HatchBabyApi {
 
   async getOnIotClient() {
     // eslint-disable-next-line prefer-const
-    let onIotClient: BehaviorSubject<AwsIotDevice> | undefined
+    let onIotClient: BehaviorSubject<AwsIotDevice> | undefined,
+      recreateInProgress = false,
+      retryDelay = iotClientInitialRetryDelay,
+      retryTimer: ReturnType<typeof setTimeout> | undefined,
+      deadConnectionTimer: ReturnType<typeof setTimeout> | undefined
 
-    const createNewIotClient = async (): Promise<AwsIotDevice> => {
-      try {
-        const previousMqttClient = onIotClient?.getValue()
-        if (previousMqttClient) {
-          try {
-            previousMqttClient.end()
-          } catch (e: unknown) {
-            logError('Failed to end previous MQTT Client')
-            logError(e)
+    const clearDeadConnectionTimer = () => {
+        if (deadConnectionTimer) {
+          clearTimeout(deadConnectionTimer)
+          deadConnectionTimer = undefined
+        }
+      },
+      attachLifecycleHandlers = (mqttClient: AwsIotDevice) => {
+        // Events from an ended, replaced client must not drive recovery for
+        // the current one. Before the subject exists this client is the one
+        // being created, so treat it as current.
+        const isCurrent = () =>
+          !onIotClient || onIotClient.getValue() === mqttClient
+
+        mqttClient.on('connect', () => {
+          if (!isCurrent()) {
+            return
           }
+          clearDeadConnectionTimer()
+          retryDelay = iotClientInitialRetryDelay
+        })
+
+        const armDeadConnectionTimer = (event: string) => {
+          if (!isCurrent() || deadConnectionTimer) {
+            return
+          }
+          deadConnectionTimer = setTimeout(() => {
+            deadConnectionTimer = undefined
+            logError(
+              `MQTT connection still down ${Math.round(iotClientDeadConnectionTimeout / 60000)} minutes after '${event}', recreating client with fresh credentials`,
+            )
+            // eslint-disable-next-line no-use-before-define
+            recreateIotClient()
+          }, iotClientDeadConnectionTimeout)
         }
 
-        logDebug('Creating new MQTT Client')
+        mqttClient.on('close', () => armDeadConnectionTimer('close'))
+        mqttClient.on('offline', () => armDeadConnectionTimer('offline'))
 
-        const mqttClient = await this.createAwsIotClient()
-
-        mqttClient.on('error', async (error) => {
+        mqttClient.on('error', (error) => {
           if (error.message.includes('(403)')) {
             logError('MQTT Client No Longer Authorized')
           } else {
@@ -138,29 +171,82 @@ export class HatchBabyApi {
             logError(error)
           }
 
-          try {
-            onIotClient?.next(await createNewIotClient())
-          } catch (_) {
-            // ignore, already logged
+          if (isCurrent()) {
+            // eslint-disable-next-line no-use-before-define
+            recreateIotClient()
           }
         })
+      },
+      createNewIotClient = async (): Promise<AwsIotDevice> => {
+        try {
+          logDebug('Creating new MQTT Client')
 
-        logDebug('Created new MQTT Client')
-        return mqttClient
-      } catch (e) {
-        logError('Failed to Create an MQTT Client')
-        logError(e)
-        throw e
+          // Create the replacement BEFORE ending the previous client: if
+          // creation fails mid-outage, the old client keeps the SDK's own
+          // reconnect loop alive instead of leaving no client at all. The
+          // old shape (end first, then create) is how the Feb 2026 outage
+          // went silent for 5 days - creation failed after the only client
+          // had already been ended, and nothing ever retried.
+          const mqttClient = await this.createAwsIotClient()
+          attachLifecycleHandlers(mqttClient)
+
+          const previousMqttClient = onIotClient?.getValue()
+          if (previousMqttClient) {
+            try {
+              previousMqttClient.end()
+            } catch (e: unknown) {
+              logError('Failed to end previous MQTT Client')
+              logError(e)
+            }
+          }
+
+          logDebug('Created new MQTT Client')
+          return mqttClient
+        } catch (e) {
+          logError('Failed to Create an MQTT Client')
+          logError(e)
+          throw e
+        }
+      },
+      recreateIotClient = async () => {
+        if (recreateInProgress) {
+          return
+        }
+        recreateInProgress = true
+        if (retryTimer) {
+          clearTimeout(retryTimer)
+          retryTimer = undefined
+        }
+        clearDeadConnectionTimer()
+
+        try {
+          const client = await createNewIotClient()
+          retryDelay = iotClientInitialRetryDelay
+          onIotClient?.next(client)
+        } catch (_) {
+          // already logged; retry with backoff, forever - an extended outage
+          // must not permanently kill the client
+          logError(
+            `Retrying MQTT client creation in ${Math.round(retryDelay / 1000)}s`,
+          )
+          retryTimer = setTimeout(() => {
+            retryTimer = undefined
+            recreateIotClient()
+          }, retryDelay)
+          retryDelay = Math.min(retryDelay * 2, iotClientMaxRetryDelay)
+        } finally {
+          recreateInProgress = false
+        }
       }
-    }
 
     onIotClient = new BehaviorSubject<AwsIotDevice>(await createNewIotClient())
 
-    onIotClient.pipe(debounceTime(iotClientRefreshPeriod)).subscribe(() => {
-      createNewIotClient()
-        .then((client) => onIotClient?.next(client))
-        .catch(logError)
-    })
+    // Proactive credential rotation. A plain interval (not debounceTime on
+    // the subject) so one failed refresh cannot permanently end the cycle,
+    // and recreateIotClient retries failures with backoff on its own.
+    setInterval(() => {
+      recreateIotClient()
+    }, iotClientRefreshPeriod)
 
     return onIotClient
   }

--- a/packages/homebridge-hatch-baby-rest/iot-device.ts
+++ b/packages/homebridge-hatch-baby-rest/iot-device.ts
@@ -116,28 +116,30 @@ export class IotDevice<T> {
       )
     })
 
+    // Attach connect handler synchronously to avoid missing the event.
+    // Previously this was deferred behind previousUpdatePromise, causing a
+    // race where 'connect' fired before the listener was registered.
+    const connectPromise = new Promise<void>((resolve) => {
+      mqttClient.on('connect', () => {
+        mqttClient.register(thingName, {}, () => {
+          getClientToken = mqttClient.get(thingName)!
+          resolve(
+            firstValueFrom(
+              this.onStatusToken.pipe(
+                filter((token) => token === getClientToken),
+              ),
+            ) as Promise<any>,
+          )
+        })
+      })
+    })
+
     this.previousUpdatePromise = this.previousUpdatePromise
       .catch((_) => {
         // ignore errors, they shouldn't be possible
         void _
       })
-      .then(
-        () =>
-          new Promise((resolve) => {
-            mqttClient.on('connect', () => {
-              mqttClient.register(thingName, {}, () => {
-                getClientToken = mqttClient.get(thingName)!
-                resolve(
-                  firstValueFrom(
-                    this.onStatusToken.pipe(
-                      filter((token) => token === getClientToken),
-                    ),
-                  ),
-                )
-              })
-            })
-          }),
-      )
+      .then(() => connectPromise)
   }
 
   getCurrentState() {

--- a/packages/homebridge-hatch-baby-rest/iot-device.ts
+++ b/packages/homebridge-hatch-baby-rest/iot-device.ts
@@ -2,7 +2,7 @@ import { RestPlusState, IotDeviceInfo } from '../shared/hatch-sleep-types.ts'
 import { thingShadow as AwsIotDevice } from 'aws-iot-device-sdk'
 import { BehaviorSubject, firstValueFrom, skip, Subject } from 'rxjs'
 import { filter } from 'rxjs/operators'
-import { delay, logDebug, logError } from '../shared/util.ts'
+import { delay, logDebug, logError, logInfo } from '../shared/util.ts'
 import { DeepPartial } from 'ts-essentials'
 
 function assignState<T = RestPlusState>(previousState: any, changes: any): T {
@@ -120,7 +120,27 @@ export class IotDevice<T> {
     // Previously this was deferred behind previousUpdatePromise, causing a
     // race where 'connect' fired before the listener was registered.
     const connectPromise = new Promise<void>((resolve) => {
+      let registered = false
       mqttClient.on('connect', () => {
+        if (registered) {
+          // SDK-internal reconnect on the same client: the thing is already
+          // registered (re-registering errors), but the shadow may have
+          // changed while we were disconnected - fetch it fresh
+          const refetchToken = mqttClient.get(thingName)
+          if (refetchToken) {
+            getClientToken = refetchToken
+            logInfo(
+              `[IotDevice] Re-fetching shadow after reconnect for ${this.name} (token: ${refetchToken})`,
+            )
+          } else {
+            logError(
+              `[IotDevice] Shadow re-fetch after reconnect returned no token for ${this.name} (operation in progress?)`,
+            )
+          }
+          return
+        }
+        registered = true
+
         mqttClient.register(thingName, {}, () => {
           getClientToken = mqttClient.get(thingName)!
           resolve(


### PR DESCRIPTION
Fixes #187

## What

Two fixes to the AWS IoT client lifecycle in `homebridge-hatch-baby-rest` so the plugin survives extended network outages instead of going permanently silent (full root-cause analysis in the referenced issue):

**Commit 1 — MQTT connect event race.** The `connect` listener was attached behind `previousUpdatePromise`, so a client that connected before the listener landed left commands blocked forever. The listener is now attached synchronously in `registerMqttClient`, with the promise chain resolving onto it.

**Commit 2 — client lifecycle overhaul (`getOnIotClient`):**

* `createNewIotClient` now creates the replacement client **before** ending the previous one. Previously, a creation failure mid-outage (token fetch, no internet) after the only client had been ended left zero clients and killed the SDK's reconnect loop with it — the permanent-death path.
* New `recreateIotClient` wrapper: re-entrancy guard, and failed creation retries with 30 s-doubling backoff (5-minute cap) forever.
* Dead-connection watchdog: `close`/`offline` arm a 10-minute timer, cleared on `connect`. The SDK's built-in reconnect reuses the original signed wss URL whose Cognito credentials expire (~1 h), so when it can't recover, the watchdog recreates the client with fresh credentials. An `isCurrent()` guard keeps events from ended, replaced clients from driving recovery.
* Credential rotation moved from `debounceTime` on the subject to a plain interval (keeping the existing 50-minute period). With `debounceTime`, one failed refresh emitted nothing and permanently disarmed the cycle; the interval retries, and `recreateIotClient` handles failures with its own backoff.
* Shadow re-fetch on SDK-internal reconnect: `register()` runs once per client (re-registering errors); subsequent `connect` events `get()` the shadow fresh so state isn't stale after a reconnect.

A changeset (`patch` for `homebridge-hatch-baby-rest`) is included.

## Verification

* `npm run build`, `npm run lint`, and `npm run test` all pass.
* The boot path (creation, registration, commands, state updates) is live-verified on a physical Hatch Restore.
* The outage paths are design-verified: they're hard to reproduce on demand, but each addressed failure mode is directly traceable in the current source, and the same create-before-end + watchdog + interval-refresh pattern is running verified on a sibling Homebridge plugin I maintain.
